### PR TITLE
Add stylus wrapper release.

### DIFF
--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -655,6 +655,7 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::parseElements() {
         stylus_wrapper->transducers->setObject(transducer);
         transducer->release();
         digitiser.transducers->setObject(0, transducer);
+        stylus_wrapper->release();
     }
 
     return kIOReturnSuccess;


### PR DESCRIPTION
This fixes VoodooI2CHID unloading on my device -- touchscreen + stylus.